### PR TITLE
Update SDK version for Go acceptance tests

### DIFF
--- a/examples/examples_go_test.go
+++ b/examples/examples_go_test.go
@@ -1,4 +1,5 @@
 // Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+//go:build go || all
 // +build go all
 
 package examples
@@ -13,7 +14,7 @@ func getGoBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	base := getBaseOptions(t)
 	baseGo := base.With(integration.ProgramTestOptions{
 		Dependencies: []string{
-			"github.com/pulumi/pulumi-akamai/sdk",
+			"github.com/pulumi/pulumi-akamai/sdk/v4",
 		},
 	})
 


### PR DESCRIPTION
Although we do not currently have any Go tests in this provider, should we ever add any, we will want to reference `sdkv4`.
