### PR TITLE
Set the read_version property if not already set

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -19,6 +19,20 @@ func TestAccEdgeHostnameTs(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestPropertyUpdate(t *testing.T) {
+	dir := path.Join(getCwd(t), "property", "ts")
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: dir,
+			EditDirs: []integration.EditDir{{
+				Dir:             path.Join(dir, "update"),
+				ExpectNoChanges: false,
+				Additive:        true,
+			}},
+		})
+	integration.ProgramTest(t, &test)
+}
+
 func getJSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	base := getBaseOptions(t)
 	baseJS := base.With(integration.ProgramTestOptions{

--- a/examples/property/ts/Pulumi.yaml
+++ b/examples/property/ts/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: akamai-property-ts
+runtime: nodejs
+description: A minimal TypeScript Pulumi program to create an Akamai Property

--- a/examples/property/ts/index.ts
+++ b/examples/property/ts/index.ts
@@ -1,0 +1,18 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as akamai from "@pulumi/akamai";
+
+const groupId = "grp_201328";
+const productId = "prd_Fresca";
+const contractId = akamai
+  .getContract({
+    groupId: groupId,
+  })
+  .then((x) => x.id);
+
+new akamai.Property("test", {
+  productId: productId,
+  contractId: contractId,
+  groupId: groupId,
+  hostnames: [],
+  ruleFormat: "v2020-03-04",
+});

--- a/examples/property/ts/package.json
+++ b/examples/property/ts/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "akamai-property-ts",
+    "devDependencies": {
+        "@types/node": "^10.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0"
+    }
+}

--- a/examples/property/ts/tsconfig.json
+++ b/examples/property/ts/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/examples/property/ts/update/index.ts
+++ b/examples/property/ts/update/index.ts
@@ -1,0 +1,23 @@
+import * as akamai from "@pulumi/akamai";
+
+const groupId = "grp_201328";
+const productId = "prd_Fresca";
+const contractId = akamai
+  .getContract({
+    groupId: groupId,
+  })
+  .then((x) => x.id);
+
+new akamai.Property("test", {
+  productId: productId,
+  contractId: contractId,
+  groupId: groupId,
+  hostnames: [
+    {
+      cnameFrom: "example.com",
+      cnameTo: "example.com.edgekey.net",
+      certProvisioningType: "DEFAULT",
+    },
+  ],
+  ruleFormat: "v2020-03-04",
+});


### PR DESCRIPTION
Fixes #107

It's not 100% clear to me why this property is special. It looks like the upstream change between 2.* and 3.* changed from the pulumi provider needing to set `"latest_version"` to and/or in addition to `"read_version"`. 

I've added a test for updating a `akamai.Property` to make sure we don't regress again.