### PR TITLE
gci linter: sort imports

### DIFF
--- a/provider/cmd/pulumi-resource-akamai/main.go
+++ b/provider/cmd/pulumi-resource-akamai/main.go
@@ -18,10 +18,12 @@ package main
 
 import (
 	"context"
+
 	_ "embed"
 
-	akamai "github.com/pulumi/pulumi-akamai/provider/v6"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
+
+	akamai "github.com/pulumi/pulumi-akamai/provider/v6"
 )
 
 //go:embed schema-embed.json

--- a/provider/cmd/pulumi-tfgen-akamai/main.go
+++ b/provider/cmd/pulumi-tfgen-akamai/main.go
@@ -15,9 +15,10 @@
 package main
 
 import (
-	akamai "github.com/pulumi/pulumi-akamai/provider/v6"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/tfgen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+
+	akamai "github.com/pulumi/pulumi-akamai/provider/v6"
 )
 
 func main() {

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -15,27 +15,27 @@
 package akamai
 
 import (
-	"fmt"
-
 	// embed is used to store bridge-metadata.json in the compiled binary
 	"context"
-	_ "embed"
+	"fmt"
 	"path/filepath"
 	"unicode"
+
+	_ "embed"
+	// Load the providers
+	_ "github.com/akamai/terraform-provider-akamai/v5/pkg/providers"
 
 	"github.com/akamai/terraform-provider-akamai/v5/pkg/akamai"
 	"github.com/akamai/terraform-provider-akamai/v5/pkg/providers/registry"
 
-	// Load the providers
-	_ "github.com/akamai/terraform-provider-akamai/v5/pkg/providers"
-
-	"github.com/pulumi/pulumi-akamai/provider/v6/pkg/version"
 	pf "github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	tks "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+
+	"github.com/pulumi/pulumi-akamai/provider/v6/pkg/version"
 )
 
 // all of the token components used below.

--- a/provider/typeReplacement_test.go
+++ b/provider/typeReplacement_test.go
@@ -3,8 +3,9 @@ package akamai
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
 func TestRecursiveReplacement(t *testing.T) {


### PR DESCRIPTION
This PR is part of a migration to standardize the order and grouping of our Go imports. See https://github.com/pulumi/upgrade-provider/pull/236.